### PR TITLE
feat: Add score input UI with GameViewModel and SwiftUI views

### DIFF
--- a/FarkleScorekeeper.xcodeproj/project.pbxproj
+++ b/FarkleScorekeeper.xcodeproj/project.pbxproj
@@ -7,13 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04953B68D7F90A866A24D5D8 /* ScoreInputPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A904A6AF840A78751FF02B2 /* ScoreInputPadView.swift */; };
 		152022153865E612D5ECE2AF /* TurnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6610A8EED5BECAF21F12CD82 /* TurnTests.swift */; };
 		4516F33F7EB35C2DB81A07B9 /* Turn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86914B16DF08EDA8A380382F /* Turn.swift */; };
 		692C663E90E0828B0AA50954 /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C95312878359D9576CEE3C /* PlayerTests.swift */; };
 		6B91316350812D4A0466A249 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFAB3FF3D403320C5C77CB2 /* Game.swift */; };
 		7EDE0C27AE2377C887A98466 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9A1A5570E7A562D5FB7EE5 /* Player.swift */; };
 		885EFCD37C87E462BA1CA9F2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FC0797CDEB35BB3E6BABB9 /* ContentView.swift */; };
+		981206CB9ABAB82D68E91668 /* GameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847808F6895C4BC0F590EDCD /* GameViewModel.swift */; };
 		AB1DA03604B0F8800D18B8A6 /* ScoringCombination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D038B71A4B1EC95C659FA84 /* ScoringCombination.swift */; };
+		AD4DDAB86BEBC903CB2C4697 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1029ADDF2BE0A8F49E7676A /* GameView.swift */; };
+		B7C9E9601AA9842BDD1ECEAF /* GameViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E9947668616E5E8889DDE2 /* GameViewModelTests.swift */; };
 		D0EA6EF54BFE5D99C0AC10DE /* GameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B5F5672730FD5906D4FFBF /* GameTests.swift */; };
 		D6A9DBDEC8DC1B7B0A1439E9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 282FE08397C8DF77146BDD6A /* Assets.xcassets */; };
 		D7840DCB5B2590D377C6C1C8 /* ScoringEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259CD983D628D307348BBF39 /* ScoringEngineTests.swift */; };
@@ -37,14 +41,18 @@
 		259CD983D628D307348BBF39 /* ScoringEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoringEngineTests.swift; sourceTree = "<group>"; };
 		282FE08397C8DF77146BDD6A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3CFAB3FF3D403320C5C77CB2 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
+		4A904A6AF840A78751FF02B2 /* ScoreInputPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreInputPadView.swift; sourceTree = "<group>"; };
+		55E9947668616E5E8889DDE2 /* GameViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewModelTests.swift; sourceTree = "<group>"; };
 		6610A8EED5BECAF21F12CD82 /* TurnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnTests.swift; sourceTree = "<group>"; };
 		76C95312878359D9576CEE3C /* PlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTests.swift; sourceTree = "<group>"; };
+		847808F6895C4BC0F590EDCD /* GameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewModel.swift; sourceTree = "<group>"; };
 		86914B16DF08EDA8A380382F /* Turn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Turn.swift; sourceTree = "<group>"; };
 		8C9A1A5570E7A562D5FB7EE5 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		953F5FCAC8AD6B8854F4209F /* ScoringCombinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoringCombinationTests.swift; sourceTree = "<group>"; };
 		D47F343803DC132397277896 /* FarkleScorekeeperTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = FarkleScorekeeperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7FC0797CDEB35BB3E6BABB9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		E38A405567B552FC049CCB77 /* FarkleScorekeeper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FarkleScorekeeper.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1029ADDF2BE0A8F49E7676A /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
 		F5CBB0929C5932379662E31D /* FarkleScorekeeperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FarkleScorekeeperApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -63,26 +71,15 @@
 		0DCD568F46373068AF59ED0A /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				55E9947668616E5E8889DDE2 /* GameViewModelTests.swift */,
 			);
 			path = Presentation;
-			sourceTree = "<group>";
-		};
-		56DB2F768A74C2B947F37E5E /* Data */ = {
-			isa = PBXGroup;
-			children = (
-				D0D9086063E5608BE4377FF2 /* Models */,
-				9CFEC5D93A4C25A5C7019565 /* Repositories */,
-			);
-			path = Data;
 			sourceTree = "<group>";
 		};
 		725930FE2F3A1EFD8E2F8C5F /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				B6BD8DE302961B1F45A4BFAE /* Components */,
 				769C8A325677B16AADEA8EB7 /* Game */,
-				B0D533060DA2642001E6F6B8 /* Setup */,
-				820EE52C2674D85AE6256F4D /* Stats */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -99,6 +96,9 @@
 		769C8A325677B16AADEA8EB7 /* Game */ = {
 			isa = PBXGroup;
 			children = (
+				F1029ADDF2BE0A8F49E7676A /* GameView.swift */,
+				847808F6895C4BC0F590EDCD /* GameViewModel.swift */,
+				4A904A6AF840A78751FF02B2 /* ScoreInputPadView.swift */,
 			);
 			path = Game;
 			sourceTree = "<group>";
@@ -106,25 +106,10 @@
 		769CB54E02F94AFDDF808CF6 /* FarkleScorekeeperTests */ = {
 			isa = PBXGroup;
 			children = (
-				A57F8ED5FBF2F2C275FA5042 /* Data */,
 				A37730A91247B1A28E1C8F26 /* Domain */,
 				0DCD568F46373068AF59ED0A /* Presentation */,
 			);
 			path = FarkleScorekeeperTests;
-			sourceTree = "<group>";
-		};
-		7C9D5E638D4559CC6ADEFACC /* UseCases */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = UseCases;
-			sourceTree = "<group>";
-		};
-		820EE52C2674D85AE6256F4D /* Stats */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Stats;
 			sourceTree = "<group>";
 		};
 		8C05E3ECD6FA21BC5DD6C1BF /* Resources */ = {
@@ -147,18 +132,9 @@
 		942496E4A59D7E122D772107 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
-				DB2BB2584AE6ED476368F860 /* Engine */,
 				08588AC480B03E3CA4B6D079 /* Entities */,
-				7C9D5E638D4559CC6ADEFACC /* UseCases */,
 			);
 			path = Domain;
-			sourceTree = "<group>";
-		};
-		9CFEC5D93A4C25A5C7019565 /* Repositories */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Repositories;
 			sourceTree = "<group>";
 		};
 		A37730A91247B1A28E1C8F26 /* Domain */ = {
@@ -173,44 +149,15 @@
 			path = Domain;
 			sourceTree = "<group>";
 		};
-		A57F8ED5FBF2F2C275FA5042 /* Data */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Data;
-			sourceTree = "<group>";
-		};
-		B0D533060DA2642001E6F6B8 /* Setup */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Setup;
-			sourceTree = "<group>";
-		};
-		B6BD8DE302961B1F45A4BFAE /* Components */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Components;
-			sourceTree = "<group>";
-		};
 		C52CC34349F229A21394B0F4 /* FarkleScorekeeper */ = {
 			isa = PBXGroup;
 			children = (
 				762387F2E689D09F9D2CDD75 /* App */,
-				56DB2F768A74C2B947F37E5E /* Data */,
 				942496E4A59D7E122D772107 /* Domain */,
 				725930FE2F3A1EFD8E2F8C5F /* Presentation */,
 				8C05E3ECD6FA21BC5DD6C1BF /* Resources */,
 			);
 			path = FarkleScorekeeper;
-			sourceTree = "<group>";
-		};
-		D0D9086063E5608BE4377FF2 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Models;
 			sourceTree = "<group>";
 		};
 		D57186564B0AC9DBF62315C5 /* Products */ = {
@@ -220,13 +167,6 @@
 				D47F343803DC132397277896 /* FarkleScorekeeperTests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		DB2BB2584AE6ED476368F860 /* Engine */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Engine;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -314,6 +254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0EA6EF54BFE5D99C0AC10DE /* GameTests.swift in Sources */,
+				B7C9E9601AA9842BDD1ECEAF /* GameViewModelTests.swift in Sources */,
 				692C663E90E0828B0AA50954 /* PlayerTests.swift in Sources */,
 				DD91E1FF0E6E3094FA837F7D /* ScoringCombinationTests.swift in Sources */,
 				D7840DCB5B2590D377C6C1C8 /* ScoringEngineTests.swift in Sources */,
@@ -328,7 +269,10 @@
 				885EFCD37C87E462BA1CA9F2 /* ContentView.swift in Sources */,
 				E02A5C4D285F9BE2BD02564C /* FarkleScorekeeperApp.swift in Sources */,
 				6B91316350812D4A0466A249 /* Game.swift in Sources */,
+				AD4DDAB86BEBC903CB2C4697 /* GameView.swift in Sources */,
+				981206CB9ABAB82D68E91668 /* GameViewModel.swift in Sources */,
 				7EDE0C27AE2377C887A98466 /* Player.swift in Sources */,
+				04953B68D7F90A866A24D5D8 /* ScoreInputPadView.swift in Sources */,
 				AB1DA03604B0F8800D18B8A6 /* ScoringCombination.swift in Sources */,
 				4516F33F7EB35C2DB81A07B9 /* Turn.swift in Sources */,
 			);

--- a/FarkleScorekeeper/App/ContentView.swift
+++ b/FarkleScorekeeper/App/ContentView.swift
@@ -2,13 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "dice")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Farkle Scorekeeper")
-        }
-        .padding()
+        GameView(playerNames: ["Player 1", "Player 2"])
     }
 }
 

--- a/FarkleScorekeeper/Presentation/Game/GameView.swift
+++ b/FarkleScorekeeper/Presentation/Game/GameView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct GameView: View {
+    @State private var viewModel: GameViewModel
+
+    init(playerNames: [String]) {
+        _viewModel = State(initialValue: GameViewModel(playerNames: playerNames))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            turnHeader
+            Divider()
+            ScrollView {
+                ScoreInputPadView(viewModel: viewModel)
+            }
+        }
+        .overlay {
+            if viewModel.isGameOver {
+                gameOverOverlay
+            }
+        }
+    }
+
+    private var turnHeader: some View {
+        VStack(spacing: 8) {
+            Text(viewModel.currentPlayerName)
+                .font(.title)
+                .fontWeight(.bold)
+
+            HStack(spacing: 24) {
+                VStack {
+                    Text("Turn Score")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(viewModel.turnScore)")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.blue)
+                }
+
+                VStack {
+                    Text("Dice Left")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(viewModel.diceRemaining)")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundStyle(viewModel.diceRemaining <= 2 ? .green : .primary)
+                }
+
+                VStack {
+                    Text("Total")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(viewModel.currentPlayerScore)")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                }
+            }
+
+            if viewModel.mustRoll && viewModel.diceRemaining > 0 {
+                Text("Must continue rolling")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            } else if viewModel.canBank {
+                Text("Can bank or continue")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+    }
+
+    private var gameOverOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.7)
+                .ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                Text("Game Over!")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.white)
+
+                if let winner = viewModel.winnerName {
+                    Text("\(winner) Wins!")
+                        .font(.title)
+                        .foregroundStyle(.yellow)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    GameView(playerNames: ["Alice", "Bob"])
+}

--- a/FarkleScorekeeper/Presentation/Game/GameViewModel.swift
+++ b/FarkleScorekeeper/Presentation/Game/GameViewModel.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+@Observable
+final class GameViewModel {
+    private var game: Game
+
+    var currentPlayerName: String {
+        game.currentPlayer.name
+    }
+
+    var currentPlayerScore: Int {
+        game.currentPlayer.score
+    }
+
+    var turnScore: Int {
+        game.currentTurn.score
+    }
+
+    var diceRemaining: Int {
+        game.currentTurn.diceRemaining
+    }
+
+    var canBank: Bool {
+        game.currentTurn.canBank
+    }
+
+    var mustRoll: Bool {
+        game.currentTurn.mustRoll
+    }
+
+    var isGameOver: Bool {
+        game.isGameOver
+    }
+
+    var winnerName: String? {
+        game.winner?.name
+    }
+
+    init(playerNames: [String]) {
+        self.game = Game(playerNames: playerNames)
+    }
+
+    func addScore(_ combination: ScoringCombination) {
+        game.addScore(combination)
+    }
+
+    @discardableResult
+    func bank() -> Bool {
+        game.bankPoints()
+    }
+
+    func farkle() {
+        game.farkle()
+    }
+
+    func isCombinationAvailable(_ combination: ScoringCombination) -> Bool {
+        guard diceRemaining >= combination.diceCount else {
+            return false
+        }
+        if combination.requiresFirstRoll && !game.currentTurn.isFirstRoll {
+            return false
+        }
+        return true
+    }
+}

--- a/FarkleScorekeeper/Presentation/Game/ScoreInputPadView.swift
+++ b/FarkleScorekeeper/Presentation/Game/ScoreInputPadView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+
+struct ScoreInputPadView: View {
+    @Bindable var viewModel: GameViewModel
+
+    var body: some View {
+        VStack(spacing: 16) {
+            singleDiceCombinations
+            threeOfAKindSection
+            multiDiceCombinations
+            sixDiceCombinations
+            actionButtons
+        }
+        .padding()
+    }
+
+    private var singleDiceCombinations: some View {
+        HStack(spacing: 12) {
+            CombinationButton(
+                title: "50",
+                subtitle: "Single 5",
+                isEnabled: viewModel.isCombinationAvailable(.singleFive)
+            ) {
+                viewModel.addScore(.singleFive)
+            }
+
+            CombinationButton(
+                title: "100",
+                subtitle: "Single 1",
+                isEnabled: viewModel.isCombinationAvailable(.singleOne)
+            ) {
+                viewModel.addScore(.singleOne)
+            }
+        }
+    }
+
+    private var threeOfAKindSection: some View {
+        VStack(spacing: 8) {
+            Text("Three of a Kind")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 8) {
+                ForEach(1...6, id: \.self) { dieValue in
+                    let combination = ScoringCombination.threeOfAKind(dieValue: dieValue)
+                    CombinationButton(
+                        title: "\(combination.points)",
+                        subtitle: "3x\(dieValue)",
+                        isEnabled: viewModel.isCombinationAvailable(combination)
+                    ) {
+                        viewModel.addScore(combination)
+                    }
+                }
+            }
+        }
+    }
+
+    private var multiDiceCombinations: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 12) {
+                CombinationButton(
+                    title: "2000",
+                    subtitle: "4 of a Kind",
+                    isEnabled: viewModel.isCombinationAvailable(.fourOfAKind)
+                ) {
+                    viewModel.addScore(.fourOfAKind)
+                }
+
+                CombinationButton(
+                    title: "3000",
+                    subtitle: "5 of a Kind",
+                    isEnabled: viewModel.isCombinationAvailable(.fiveOfAKind)
+                ) {
+                    viewModel.addScore(.fiveOfAKind)
+                }
+            }
+
+            HStack(spacing: 12) {
+                CombinationButton(
+                    title: "1500",
+                    subtitle: "Small Straight",
+                    isEnabled: viewModel.isCombinationAvailable(.smallStraight)
+                ) {
+                    viewModel.addScore(.smallStraight)
+                }
+
+                fullHouseMenu
+            }
+        }
+    }
+
+    private var fullHouseMenu: some View {
+        Menu {
+            ForEach(1...6, id: \.self) { tripletValue in
+                let combination = ScoringCombination.fullHouse(tripletValue: tripletValue)
+                Button("\(combination.points) (3x\(tripletValue) + pair)") {
+                    viewModel.addScore(combination)
+                }
+                .disabled(!viewModel.isCombinationAvailable(combination))
+            }
+        } label: {
+            CombinationButtonLabel(
+                title: "Full House",
+                subtitle: "3+2",
+                isEnabled: viewModel.isCombinationAvailable(.fullHouse(tripletValue: 1))
+            )
+        }
+        .disabled(!viewModel.isCombinationAvailable(.fullHouse(tripletValue: 1)))
+    }
+
+    private var sixDiceCombinations: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 12) {
+                CombinationButton(
+                    title: "10000",
+                    subtitle: "6 of a Kind",
+                    isEnabled: viewModel.isCombinationAvailable(.sixOfAKind)
+                ) {
+                    viewModel.addScore(.sixOfAKind)
+                }
+
+                CombinationButton(
+                    title: "WIN!",
+                    subtitle: "6 Ones",
+                    isEnabled: viewModel.isCombinationAvailable(.sixOnes)
+                ) {
+                    viewModel.addScore(.sixOnes)
+                }
+            }
+
+            HStack(spacing: 12) {
+                CombinationButton(
+                    title: "1500",
+                    subtitle: "Large Straight",
+                    isEnabled: viewModel.isCombinationAvailable(.largeStraight)
+                ) {
+                    viewModel.addScore(.largeStraight)
+                }
+
+                CombinationButton(
+                    title: "1500",
+                    subtitle: "Three Pairs",
+                    isEnabled: viewModel.isCombinationAvailable(.threePairs)
+                ) {
+                    viewModel.addScore(.threePairs)
+                }
+            }
+
+            HStack(spacing: 12) {
+                CombinationButton(
+                    title: "2500",
+                    subtitle: "Two Triplets",
+                    isEnabled: viewModel.isCombinationAvailable(.twoTriplets)
+                ) {
+                    viewModel.addScore(.twoTriplets)
+                }
+
+                CombinationButton(
+                    title: "2250",
+                    subtitle: "Full Mansion",
+                    isEnabled: viewModel.isCombinationAvailable(.fullMansion)
+                ) {
+                    viewModel.addScore(.fullMansion)
+                }
+            }
+
+            CombinationButton(
+                title: "500",
+                subtitle: "Six-Dice Farkle",
+                isEnabled: viewModel.isCombinationAvailable(.sixDiceFarkle)
+            ) {
+                viewModel.addScore(.sixDiceFarkle)
+            }
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 16) {
+            Button {
+                viewModel.farkle()
+            } label: {
+                Text("FARKLE!")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.red.opacity(0.8))
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            Button {
+                viewModel.bank()
+            } label: {
+                Text("BANK")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(viewModel.canBank ? Color.green : Color.gray)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .disabled(!viewModel.canBank)
+        }
+    }
+}
+
+struct CombinationButton: View {
+    let title: String
+    let subtitle: String
+    let isEnabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            CombinationButtonLabel(title: title, subtitle: subtitle, isEnabled: isEnabled)
+        }
+        .disabled(!isEnabled)
+    }
+}
+
+struct CombinationButtonLabel: View {
+    let title: String
+    let subtitle: String
+    let isEnabled: Bool
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.title2)
+                .fontWeight(.bold)
+            Text(subtitle)
+                .font(.caption)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(isEnabled ? Color.blue.opacity(0.8) : Color.gray.opacity(0.3))
+        .foregroundStyle(isEnabled ? .white : .secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+#Preview {
+    ScoreInputPadView(viewModel: GameViewModel(playerNames: ["Alice", "Bob"]))
+}

--- a/FarkleScorekeeperTests/Presentation/GameViewModelTests.swift
+++ b/FarkleScorekeeperTests/Presentation/GameViewModelTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+
+@testable import FarkleScorekeeper
+
+final class GameViewModelTests: XCTestCase {
+
+    // MARK: - Initialization Tests
+
+    func test_init_exposesCurrentPlayerName() {
+        let viewModel = GameViewModel(playerNames: ["Alice", "Bob"])
+
+        XCTAssertEqual(viewModel.currentPlayerName, "Alice")
+    }
+
+    func test_init_turnScoreIsZero() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertEqual(viewModel.turnScore, 0)
+    }
+
+    func test_init_diceRemainingIsSix() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertEqual(viewModel.diceRemaining, 6)
+    }
+
+    // MARK: - Add Score Tests
+
+    func test_addScore_singleOne_increasesTurnScoreBy100() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+
+        viewModel.addScore(.singleOne)
+
+        XCTAssertEqual(viewModel.turnScore, 100)
+    }
+
+    func test_addScore_singleOne_decreasesDiceRemainingByOne() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+
+        viewModel.addScore(.singleOne)
+
+        XCTAssertEqual(viewModel.diceRemaining, 5)
+    }
+
+    func test_addScore_threeOfAKind_decreasesDiceRemainingByThree() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+
+        viewModel.addScore(.threeOfAKind(dieValue: 3))
+
+        XCTAssertEqual(viewModel.diceRemaining, 3)
+    }
+
+    // MARK: - Bank Tests
+
+    func test_canBank_withSixDice_isFalse() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertFalse(viewModel.canBank)
+    }
+
+    func test_canBank_withTwoDice_isTrue() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.fourOfAKind)
+
+        XCTAssertTrue(viewModel.canBank)
+    }
+
+    func test_bank_addsScoreToPlayerTotal() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.fourOfAKind)
+
+        let banked = viewModel.bank()
+
+        XCTAssertTrue(banked)
+        XCTAssertEqual(viewModel.currentPlayerScore, 2000)
+    }
+
+    // MARK: - Farkle Tests
+
+    func test_farkle_advancesToNextPlayer() {
+        var viewModel = GameViewModel(playerNames: ["Alice", "Bob"])
+
+        viewModel.farkle()
+
+        XCTAssertEqual(viewModel.currentPlayerName, "Bob")
+    }
+
+    func test_farkle_resetsTurnScore() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        viewModel.farkle()
+
+        XCTAssertEqual(viewModel.turnScore, 0)
+    }
+
+    // MARK: - Must Roll Tests
+
+    func test_mustRoll_withSixDice_isTrue() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertTrue(viewModel.mustRoll)
+    }
+
+    func test_mustRoll_withThreeDice_isTrue() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.threeOfAKind(dieValue: 2))
+
+        XCTAssertTrue(viewModel.mustRoll)
+    }
+
+    func test_mustRoll_withTwoDice_isFalse() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.fourOfAKind)
+
+        XCTAssertFalse(viewModel.mustRoll)
+    }
+
+    // MARK: - Available Combinations Tests
+
+    func test_isCombinationAvailable_singleOne_withOneDie_isTrue() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.fiveOfAKind)
+
+        XCTAssertTrue(viewModel.isCombinationAvailable(.singleOne))
+    }
+
+    func test_isCombinationAvailable_threeOfAKind_withTwoDice_isFalse() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.fourOfAKind)
+
+        XCTAssertFalse(viewModel.isCombinationAvailable(.threeOfAKind(dieValue: 3)))
+    }
+
+    func test_isCombinationAvailable_sixDiceFarkle_onFirstRoll_isTrue() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertTrue(viewModel.isCombinationAvailable(.sixDiceFarkle))
+    }
+
+    func test_isCombinationAvailable_sixDiceFarkle_afterScoring_isFalse() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        XCTAssertFalse(viewModel.isCombinationAvailable(.sixDiceFarkle))
+    }
+
+    // MARK: - Game State Tests
+
+    func test_isGameOver_initiallyFalse() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertFalse(viewModel.isGameOver)
+    }
+
+    func test_winnerName_whenNoWinner_isNil() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertNil(viewModel.winnerName)
+    }
+}


### PR DESCRIPTION
## Summary

- Implement GameViewModel as Observable wrapper around Game domain model
- Create ScoreInputPadView with button grid for all scoring combinations
- Add GameView as main game screen with turn header and score input pad
- Follow strict TDD with 20 new ViewModel tests (107 total tests passing)

## Changes

### GameViewModel (`FarkleScorekeeper/Presentation/Game/GameViewModel.swift`)
- Exposes turn score, dice remaining, current player info
- Actions: `addScore()`, `bank()`, `farkle()`
- `isCombinationAvailable()` for enabling/disabling buttons based on dice count and first roll status

### ScoreInputPadView (`FarkleScorekeeper/Presentation/Game/ScoreInputPadView.swift`)
- Single dice combinations (50 for single 5, 100 for single 1)
- Three of a kind section with die value selection (1-6)
- Multi-dice combinations (4/5/6 of a kind, straights, full house)
- Six-dice combinations (large straight, three pairs, two triplets, full mansion)
- Bank and Farkle action buttons with proper enable/disable state

### GameView (`FarkleScorekeeper/Presentation/Game/GameView.swift`)
- Turn header showing current player, turn score, dice remaining, total score
- Status text for "Must continue rolling" vs "Can bank or continue"
- Scrollable score input pad
- Game over overlay with winner announcement

## Test Plan

- [x] All 107 unit tests pass
- [x] Build succeeds on iOS Simulator
- [ ] Manual testing of score input flow
- [ ] Verify button enable/disable states match dice remaining
- [ ] Verify bank button only enabled with 1-2 dice remaining
- [ ] Verify six-dice farkle only available on first roll