### PR TITLE
feat: Add undo functionality for score entry (#18)

### DIFF
--- a/FarkleScorekeeper/App/AppColors.swift
+++ b/FarkleScorekeeper/App/AppColors.swift
@@ -31,6 +31,14 @@ enum AppColors {
         static var bankDisabledBackground: Color {
             Color.gray
         }
+
+        static var undoEnabledBackground: Color {
+            Color.orange
+        }
+
+        static var undoDisabledBackground: Color {
+            Color.gray
+        }
     }
 
     // MARK: - Score Colors

--- a/FarkleScorekeeper/Domain/Entities/Game.swift
+++ b/FarkleScorekeeper/Domain/Entities/Game.swift
@@ -51,6 +51,10 @@ struct Game: Sendable {
         currentTurn.addScore(combination)
     }
 
+    mutating func undoLastScore() {
+        currentTurn.undoLastScore()
+    }
+
     mutating func bankPoints() -> Bool {
         guard currentTurn.canBank else {
             return false

--- a/FarkleScorekeeper/Domain/Entities/Turn.swift
+++ b/FarkleScorekeeper/Domain/Entities/Turn.swift
@@ -5,9 +5,14 @@ struct Turn: Sendable {
     var diceRemaining: Int = 6
     var isFirstRoll: Bool = true
     private(set) var scoringHistory: [ScoringCombination] = []
+    private var hotDiceTriggeredIndices: Set<Int> = []
 
     var canBank: Bool {
         diceRemaining <= 2 && diceRemaining > 0
+    }
+
+    var canUndo: Bool {
+        !scoringHistory.isEmpty
     }
 
     var mustRoll: Bool {
@@ -21,6 +26,7 @@ struct Turn: Sendable {
         scoringHistory.append(combination)
 
         if diceRemaining == 0 {
+            hotDiceTriggeredIndices.insert(scoringHistory.count - 1)
             hotDice()
         }
     }
@@ -31,5 +37,27 @@ struct Turn: Sendable {
 
     mutating func hotDice() {
         diceRemaining = 6
+    }
+
+    mutating func undoLastScore() {
+        guard !scoringHistory.isEmpty else {
+            return
+        }
+
+        let undoIndex = scoringHistory.count - 1
+        let lastCombination = scoringHistory.removeLast()
+
+        score -= lastCombination.points
+
+        if hotDiceTriggeredIndices.contains(undoIndex) {
+            hotDiceTriggeredIndices.remove(undoIndex)
+            diceRemaining = 0
+        }
+
+        diceRemaining += lastCombination.diceCount
+
+        if scoringHistory.isEmpty {
+            isFirstRoll = true
+        }
     }
 }

--- a/FarkleScorekeeper/Presentation/Game/GameViewModel.swift
+++ b/FarkleScorekeeper/Presentation/Game/GameViewModel.swift
@@ -32,6 +32,10 @@ final class GameViewModel {
         game.currentTurn.scoringHistory
     }
 
+    var canUndo: Bool {
+        game.currentTurn.canUndo
+    }
+
     var isGameOver: Bool {
         game.isGameOver
     }
@@ -55,6 +59,10 @@ final class GameViewModel {
 
     func farkle() {
         game.farkle()
+    }
+
+    func undo() {
+        game.undoLastScore()
     }
 
     func isCombinationAvailable(_ combination: ScoringCombination) -> Bool {

--- a/FarkleScorekeeper/Presentation/Game/ScoreInputPadView.swift
+++ b/FarkleScorekeeper/Presentation/Game/ScoreInputPadView.swift
@@ -182,6 +182,20 @@ struct ScoreInputPadView: View {
     private var actionButtons: some View {
         HStack(spacing: 16) {
             Button {
+                viewModel.undo()
+            } label: {
+                Text("UNDO")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(viewModel.canUndo ? AppColors.Button.undoEnabledBackground : AppColors.Button.undoDisabledBackground)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .disabled(!viewModel.canUndo)
+            .accessibilityIdentifier("undoButton")
+
+            Button {
                 viewModel.farkle()
             } label: {
                 Text("FARKLE!")

--- a/FarkleScorekeeperTests/Domain/TurnTests.swift
+++ b/FarkleScorekeeperTests/Domain/TurnTests.swift
@@ -193,4 +193,123 @@ final class TurnTests: XCTestCase {
 
         XCTAssertEqual(turn.scoringHistory.count, 2)
     }
+
+    // MARK: - undoLastScore Tests
+
+    func test_undoLastScore_subtractsCombinationPointsFromScore() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.score, 0)
+    }
+
+    func test_undoLastScore_restoresDiceRemaining() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.diceRemaining, 6)
+    }
+
+    func test_undoLastScore_removesFromScoringHistory() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+
+        turn.undoLastScore()
+
+        XCTAssertTrue(turn.scoringHistory.isEmpty)
+    }
+
+    func test_undoLastScore_restoresIsFirstRoll_whenUndoingOnlyEntry() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+
+        turn.undoLastScore()
+
+        XCTAssertTrue(turn.isFirstRoll)
+    }
+
+    func test_undoLastScore_keepsIsFirstRollFalse_whenHistoryNotEmpty() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+        turn.addScore(.singleFive)
+
+        turn.undoLastScore()
+
+        XCTAssertFalse(turn.isFirstRoll)
+    }
+
+    func test_undoLastScore_undoesMultipleEntriesInSequence() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+        turn.addScore(.singleFive)
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.score, 100)
+        XCTAssertEqual(turn.diceRemaining, 5)
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.score, 0)
+        XCTAssertEqual(turn.diceRemaining, 6)
+    }
+
+    func test_undoLastScore_doesNothing_whenHistoryEmpty() {
+        var turn = Turn()
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.score, 0)
+        XCTAssertEqual(turn.diceRemaining, 6)
+        XCTAssertTrue(turn.isFirstRoll)
+    }
+
+    func test_undoLastScore_afterHotDice_restoresPreviousState() {
+        var turn = Turn()
+        turn.addScore(.largeStraight)
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.score, 0)
+        XCTAssertEqual(turn.diceRemaining, 6)
+        XCTAssertTrue(turn.isFirstRoll)
+    }
+
+    func test_undoLastScore_afterScoringPostHotDice_restoresHotDiceState() {
+        var turn = Turn()
+        turn.addScore(.largeStraight)
+        turn.addScore(.singleOne)
+
+        turn.undoLastScore()
+
+        XCTAssertEqual(turn.score, 1500)
+        XCTAssertEqual(turn.diceRemaining, 6)
+    }
+
+    // MARK: - canUndo Tests
+
+    func test_canUndo_onNewTurn_isFalse() {
+        let turn = Turn()
+
+        XCTAssertFalse(turn.canUndo)
+    }
+
+    func test_canUndo_afterAddingScore_isTrue() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+
+        XCTAssertTrue(turn.canUndo)
+    }
+
+    func test_canUndo_afterUndoingAllEntries_isFalse() {
+        var turn = Turn()
+        turn.addScore(.singleOne)
+        turn.undoLastScore()
+
+        XCTAssertFalse(turn.canUndo)
+    }
 }

--- a/FarkleScorekeeperTests/Presentation/GameViewModelTests.swift
+++ b/FarkleScorekeeperTests/Presentation/GameViewModelTests.swift
@@ -218,4 +218,84 @@ final class GameViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.turnScoringHistory.isEmpty)
     }
+
+    // MARK: - Undo Tests
+
+    func test_canUndo_atStartOfTurn_isFalse() {
+        let viewModel = GameViewModel(playerNames: ["Alice"])
+
+        XCTAssertFalse(viewModel.canUndo)
+    }
+
+    func test_canUndo_afterAddingScore_isTrue() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        XCTAssertTrue(viewModel.canUndo)
+    }
+
+    func test_canUndo_afterFarkle_isFalse() {
+        var viewModel = GameViewModel(playerNames: ["Alice", "Bob"])
+        viewModel.addScore(.singleOne)
+        viewModel.farkle()
+
+        XCTAssertFalse(viewModel.canUndo)
+    }
+
+    func test_canUndo_afterBanking_isFalse() {
+        var viewModel = GameViewModel(playerNames: ["Alice", "Bob"])
+        viewModel.addScore(.fourOfAKind)
+        viewModel.bank()
+
+        XCTAssertFalse(viewModel.canUndo)
+    }
+
+    func test_undo_restoresTurnScore() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        viewModel.undo()
+
+        XCTAssertEqual(viewModel.turnScore, 0)
+    }
+
+    func test_undo_restoresDiceRemaining() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        viewModel.undo()
+
+        XCTAssertEqual(viewModel.diceRemaining, 6)
+    }
+
+    func test_undo_removesFromScoringHistory() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        viewModel.undo()
+
+        XCTAssertTrue(viewModel.turnScoringHistory.isEmpty)
+    }
+
+    func test_undo_afterMultipleScores_restoresLastState() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+        viewModel.addScore(.singleFive)
+
+        viewModel.undo()
+
+        XCTAssertEqual(viewModel.turnScore, 100)
+        XCTAssertEqual(viewModel.diceRemaining, 5)
+    }
+
+    func test_undo_restoresSixDiceFarkleAvailability() {
+        var viewModel = GameViewModel(playerNames: ["Alice"])
+        viewModel.addScore(.singleOne)
+
+        XCTAssertFalse(viewModel.isCombinationAvailable(.sixDiceFarkle))
+
+        viewModel.undo()
+
+        XCTAssertTrue(viewModel.isCombinationAvailable(.sixDiceFarkle))
+    }
 }


### PR DESCRIPTION
## Summary
- Add `undoLastScore()` method to Turn entity with proper hot dice tracking
- Add `canUndo` property to control undo button state
- Add UNDO button to ScoreInputPadView with orange styling
- Add undo colors to AppColors

## Implementation Details
The undo feature tracks hot dice state by recording which indices in the scoring history triggered hot dice. When undoing:
- Restores dice count correctly even after hot dice was triggered
- Maintains proper turn state (isFirstRoll, score)
- Disables undo when no scores to undo

## Test Plan
- [x] Unit tests for Turn.undoLastScore() basic functionality
- [x] Unit tests for hot dice undo scenarios
- [x] Unit tests for canUndo property
- [x] ViewModel tests for undo integration
- [x] UI button renders with correct disabled/enabled states

Closes #18