### PR TITLE
fix: Use callback pattern for color and icon pickers with @Observable

### DIFF
--- a/FarkleScorekeeper/Presentation/Setup/PlayerColorPickerView.swift
+++ b/FarkleScorekeeper/Presentation/Setup/PlayerColorPickerView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct PlayerColorPickerView: View {
-    @Binding var selectedColor: PlayerColor
+    let selectedColor: PlayerColor
+    let onSelect: (PlayerColor) -> Void
 
     private let columns = [
         GridItem(.adaptive(minimum: 44))
@@ -11,7 +12,7 @@ struct PlayerColorPickerView: View {
         LazyVGrid(columns: columns, spacing: 8) {
             ForEach(PlayerColor.allCases, id: \.self) { color in
                 Button {
-                    selectedColor = color
+                    onSelect(color)
                 } label: {
                     Circle()
                         .fill(color.swiftUIColor)
@@ -39,7 +40,9 @@ struct PlayerColorPickerView: View {
         var body: some View {
             VStack {
                 Text("Selected: \(color.rawValue)")
-                PlayerColorPickerView(selectedColor: $color)
+                PlayerColorPickerView(selectedColor: color) { newColor in
+                    color = newColor
+                }
             }
             .padding()
         }

--- a/FarkleScorekeeper/Presentation/Setup/PlayerIconPickerView.swift
+++ b/FarkleScorekeeper/Presentation/Setup/PlayerIconPickerView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct PlayerIconPickerView: View {
-    @Binding var selectedIcon: String
+    let selectedIcon: String
+    let onSelect: (String) -> Void
 
     private let columns = [
         GridItem(.adaptive(minimum: 44))
@@ -11,7 +12,7 @@ struct PlayerIconPickerView: View {
         LazyVGrid(columns: columns, spacing: 8) {
             ForEach(PlayerIcon.defaultEmojis, id: \.self) { iconName in
                 Button {
-                    selectedIcon = iconName
+                    onSelect(iconName)
                 } label: {
                     Text(PlayerIcon.displayText(for: iconName) ?? iconName)
                         .font(.title2)
@@ -44,7 +45,9 @@ struct PlayerIconPickerView: View {
         var body: some View {
             VStack {
                 Text("Selected: \(PlayerIcon.displayText(for: icon) ?? icon)")
-                PlayerIconPickerView(selectedIcon: $icon)
+                PlayerIconPickerView(selectedIcon: icon) { newIcon in
+                    icon = newIcon
+                }
             }
             .padding()
         }

--- a/FarkleScorekeeper/Presentation/Setup/PlayerSetupView.swift
+++ b/FarkleScorekeeper/Presentation/Setup/PlayerSetupView.swift
@@ -23,12 +23,20 @@ struct PlayerSetupView: View {
                                 Text("Choose Color")
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
-                                PlayerColorPickerView(selectedColor: $viewModel.playerColors[index])
+                                PlayerColorPickerView(
+                                    selectedColor: viewModel.playerColors[index]
+                                ) { color in
+                                    viewModel.setPlayerColor(at: index, to: color)
+                                }
 
                                 Text("Choose Icon")
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
-                                PlayerIconPickerView(selectedIcon: $viewModel.playerIcons[index])
+                                PlayerIconPickerView(
+                                    selectedIcon: viewModel.playerIcons[index]
+                                ) { icon in
+                                    viewModel.setPlayerIcon(at: index, to: icon)
+                                }
                             }
                             .padding(.vertical, 4)
                         }

--- a/FarkleScorekeeper/Presentation/Setup/PlayerSetupViewModel.swift
+++ b/FarkleScorekeeper/Presentation/Setup/PlayerSetupViewModel.swift
@@ -64,6 +64,16 @@ final class PlayerSetupViewModel {
         recentNamesRepository.save(namesToSave)
     }
 
+    func setPlayerColor(at index: Int, to color: PlayerColor) {
+        guard index >= 0, index < playerColors.count else { return }
+        playerColors[index] = color
+    }
+
+    func setPlayerIcon(at index: Int, to icon: String) {
+        guard index >= 0, index < playerIcons.count else { return }
+        playerIcons[index] = icon
+    }
+
     private func adjustPlayerData() {
         adjustPlayerNames()
         adjustPlayerColors()

--- a/FarkleScorekeeperTests/Presentation/Setup/PlayerSetupViewModelTests.swift
+++ b/FarkleScorekeeperTests/Presentation/Setup/PlayerSetupViewModelTests.swift
@@ -237,6 +237,23 @@ final class PlayerSetupViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.playerColors.count, 2)
     }
 
+    func test_setPlayerColor_updatesColorAtIndex() {
+        let viewModel = PlayerSetupViewModel()
+
+        viewModel.setPlayerColor(at: 0, to: .purple)
+
+        XCTAssertEqual(viewModel.playerColors[0], .purple)
+    }
+
+    func test_setPlayerColor_preservesOtherColors() {
+        let viewModel = PlayerSetupViewModel()
+        let originalSecondColor = viewModel.playerColors[1]
+
+        viewModel.setPlayerColor(at: 0, to: .purple)
+
+        XCTAssertEqual(viewModel.playerColors[1], originalSecondColor)
+    }
+
     // MARK: - Icon Selection Tests
 
     func test_init_playerIconsHasCorrectCount() {
@@ -270,6 +287,23 @@ final class PlayerSetupViewModelTests: XCTestCase {
         viewModel.playerCount = 2
 
         XCTAssertEqual(viewModel.playerIcons.count, 2)
+    }
+
+    func test_setPlayerIcon_updatesIconAtIndex() {
+        let viewModel = PlayerSetupViewModel()
+
+        viewModel.setPlayerIcon(at: 0, to: "rocket")
+
+        XCTAssertEqual(viewModel.playerIcons[0], "rocket")
+    }
+
+    func test_setPlayerIcon_preservesOtherIcons() {
+        let viewModel = PlayerSetupViewModel()
+        let originalSecondIcon = viewModel.playerIcons[1]
+
+        viewModel.setPlayerIcon(at: 0, to: "rocket")
+
+        XCTAssertEqual(viewModel.playerIcons[1], originalSecondIcon)
     }
 
     // MARK: - Player Config Tests


### PR DESCRIPTION
## Summary

- Fix color and icon selection not working in player setup screen
- The `@Observable` macro doesn't support projectable bindings for array elements (`$viewModel.array[index]` syntax), causing selections to silently fail
- Replaced `@Binding`-based picker views with callback pattern (`selectedValue`/`onSelect`)
- Added explicit setter methods to `PlayerSetupViewModel` for color and icon updates

## Root Cause

When using Swift's `@Observable` macro (new in iOS 17), you cannot use `$viewModel.playerColors[index]` to create a binding to an array element. The binding is created but writes don't properly trigger observation, causing the selection to appear to always set the last color (yellow).

## Solution

Changed from binding pattern:
```swift
PlayerColorPickerView(selectedColor: $viewModel.playerColors[index])
```

To callback pattern:
```swift
PlayerColorPickerView(selectedColor: viewModel.playerColors[index]) { color in
    viewModel.setPlayerColor(at: index, to: color)
}
```

## Test plan

- [x] Added unit tests for `setPlayerColor(at:to:)` and `setPlayerIcon(at:to:)` methods
- [x] All existing unit tests pass (33 tests)
- [x] All UI tests pass (30 tests)
- [ ] Manual test: Tap to expand player 1, select different colors - verify selection sticks
- [ ] Manual test: Select different icons - verify selection sticks
- [ ] Manual test: Start game and verify selected colors/icons appear in game view

Fixes #20