### PR TITLE
fix: Add borderless button style to picker buttons inside Form

### DIFF
--- a/FarkleScorekeeper.xcodeproj/project.pbxproj
+++ b/FarkleScorekeeper.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6B91316350812D4A0466A249 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFAB3FF3D403320C5C77CB2 /* Game.swift */; };
 		6DF8B82B5828CFB4D36DB22F /* PlayerIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C7B10906517DE710D62F79 /* PlayerIconTests.swift */; };
 		76FE62E007F7D12208D0DF29 /* TurnHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0119440FEB5EF7E8182C593F /* TurnHistoryView.swift */; };
+		7781431E6368E2054A6EDD34 /* PlayerSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756845150C9F398DFB1CEF6 /* PlayerSetupTests.swift */; };
 		7EDE0C27AE2377C887A98466 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9A1A5570E7A562D5FB7EE5 /* Player.swift */; };
 		7FFE95DDFA3D307E3E686984 /* GameResultsFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CADD1CF07415BD96060A5E /* GameResultsFormatter.swift */; };
 		800857AB149F966A0B2D5EDB /* FinalRoundBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38DED41DE0E17DAAC9C6E44E /* FinalRoundBannerView.swift */; };
@@ -99,6 +100,7 @@
 		282FE08397C8DF77146BDD6A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2A79AD252AB8E2FF0A7BF0B3 /* PlayerStatisticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStatisticsTests.swift; sourceTree = "<group>"; };
 		2AA835FA32E5939F682BE517 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
+		3756845150C9F398DFB1CEF6 /* PlayerSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSetupTests.swift; sourceTree = "<group>"; };
 		38DED41DE0E17DAAC9C6E44E /* FinalRoundBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalRoundBannerView.swift; sourceTree = "<group>"; };
 		38F95C0899EA6875451E97BD /* PlayerStatisticsRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerStatisticsRecord.swift; sourceTree = "<group>"; };
 		3CFAB3FF3D403320C5C77CB2 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 		75BF32855FCA88ED446E0F7C /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				3756845150C9F398DFB1CEF6 /* PlayerSetupTests.swift */,
 				E895275D181F1153ECDA05E7 /* ScoringTests.swift */,
 				3ED837878B135478BEB8310F /* TurnManagementTests.swift */,
 			);
@@ -563,6 +566,7 @@
 			files = (
 				D465D0D3D827842BBE865420 /* BDDTestCase.swift in Sources */,
 				543687A9445717FA69632D0A /* GameSteps.swift in Sources */,
+				7781431E6368E2054A6EDD34 /* PlayerSetupTests.swift in Sources */,
 				C687BEC9886902DE578ABCB7 /* ScoringTests.swift in Sources */,
 				69EA2B2ADFAFE95FA0204A00 /* TurnManagementTests.swift in Sources */,
 			);

--- a/FarkleScorekeeper/Presentation/Setup/PlayerColorPickerView.swift
+++ b/FarkleScorekeeper/Presentation/Setup/PlayerColorPickerView.swift
@@ -25,6 +25,7 @@ struct PlayerColorPickerView: View {
                         }
                         .shadow(color: selectedColor == color ? color.swiftUIColor.opacity(0.5) : .clear, radius: 4)
                 }
+                .buttonStyle(.borderless)
                 .accessibilityLabel(color.rawValue)
                 .accessibilityAddTraits(selectedColor == color ? .isSelected : [])
             }

--- a/FarkleScorekeeper/Presentation/Setup/PlayerIconPickerView.swift
+++ b/FarkleScorekeeper/Presentation/Setup/PlayerIconPickerView.swift
@@ -30,6 +30,7 @@ struct PlayerIconPickerView: View {
                             }
                         }
                 }
+                .buttonStyle(.borderless)
                 .accessibilityLabel(iconName)
                 .accessibilityAddTraits(selectedIcon == iconName ? .isSelected : [])
             }

--- a/FarkleScorekeeperUITests/Features/PlayerSetupTests.swift
+++ b/FarkleScorekeeperUITests/Features/PlayerSetupTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+final class PlayerSetupTests: BDDTestCase {
+
+    func test_colorPicker_selectingRedChangesColorToRed() {
+        given("the app is launched") {
+            app.launch()
+        }
+
+        when("I tap to customize Player 1") {
+            let customizeButton = app.buttons["customizePlayer0"]
+            XCTAssertTrue(customizeButton.waitForExistence(timeout: 5), "Customize button should exist")
+            customizeButton.tap()
+        }
+
+        and("I tap the red color") {
+            let redButton = app.buttons["red"]
+            XCTAssertTrue(redButton.waitForExistence(timeout: 5), "Red color button should exist")
+            redButton.tap()
+        }
+
+        then("the selected color indicator shows on red") {
+            let redButton = app.buttons["red"]
+            XCTAssertTrue(redButton.isSelected, "Red button should be selected")
+        }
+    }
+
+    func test_colorPicker_selectingPurpleChangesColorToPurple() {
+        given("the app is launched") {
+            app.launch()
+        }
+
+        when("I tap to customize Player 1") {
+            let customizeButton = app.buttons["customizePlayer0"]
+            XCTAssertTrue(customizeButton.waitForExistence(timeout: 5), "Customize button should exist")
+            customizeButton.tap()
+        }
+
+        and("I tap the purple color") {
+            let purpleButton = app.buttons["purple"]
+            XCTAssertTrue(purpleButton.waitForExistence(timeout: 5), "Purple color button should exist")
+            purpleButton.tap()
+        }
+
+        then("the selected color indicator shows on purple") {
+            let purpleButton = app.buttons["purple"]
+            XCTAssertTrue(purpleButton.isSelected, "Purple button should be selected")
+        }
+    }
+
+    func test_colorPicker_doesNotSelectYellowWhenTappingRed() {
+        given("the app is launched") {
+            app.launch()
+        }
+
+        when("I tap to customize Player 1") {
+            let customizeButton = app.buttons["customizePlayer0"]
+            XCTAssertTrue(customizeButton.waitForExistence(timeout: 5), "Customize button should exist")
+            customizeButton.tap()
+        }
+
+        and("I tap the red color") {
+            let redButton = app.buttons["red"]
+            XCTAssertTrue(redButton.waitForExistence(timeout: 5), "Red color button should exist")
+            redButton.tap()
+        }
+
+        then("yellow is NOT selected") {
+            let yellowButton = app.buttons["yellow"]
+            XCTAssertFalse(yellowButton.isSelected, "Yellow button should NOT be selected when tapping red")
+        }
+
+        and("red IS selected") {
+            let redButton = app.buttons["red"]
+            XCTAssertTrue(redButton.isSelected, "Red button should be selected")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes color/icon picker buttons selecting wrong item (always yellow/last) inside SwiftUI Form
- Adds `.buttonStyle(.borderless)` to picker buttons to prevent Form gesture interference
- Adds UI tests to verify color picker selection behavior

## Root Cause

SwiftUI Form has special gesture handling for buttons. Without an explicit button style, Form was intercepting touch events in the LazyVGrid and causing unexpected behavior where tapping any color would select the last color (yellow) instead of the intended one.

## Test Plan

- [x] Run `test_colorPicker_selectingRedChangesColorToRed` - verifies red selection works
- [x] Run `test_colorPicker_selectingPurpleChangesColorToPurple` - verifies purple selection works  
- [x] Run `test_colorPicker_doesNotSelectYellowWhenTappingRed` - verifies yellow is NOT selected when tapping red
- [x] All existing tests pass (33 tests)
- [x] Manual testing in simulator confirms fix

## Files Changed

- `PlayerColorPickerView.swift` - Added `.buttonStyle(.borderless)` to color buttons
- `PlayerIconPickerView.swift` - Added `.buttonStyle(.borderless)` to icon buttons
- `PlayerSetupTests.swift` - New UI tests for color picker behavior